### PR TITLE
fix permissions for udev rule on Ubuntu 10.04

### DIFF
--- a/linux/40-novint-falcon-udev.rules
+++ b/linux/40-novint-falcon-udev.rules
@@ -1,2 +1,2 @@
-SYSFS{idVendor}=="0403", SYSFS{idProduct}=="cb48", MODE="0666", SYMLINK+="novint_falcon_%k"
-SUBSYSTEM=="usb", ACTION=="add", ENV{DEVTYPE}=="usb_device", SYSFS{idVendor}=="0403", SYSFS{idProduct}=="cb48", NAME="bus/usb/$env{BUSNUM}/$env{DEVNUM}", MODE="0666"
+SYSFS{idVendor}=="0403", SYSFS{idProduct}=="cb48", MODE="0666", SYMLINK+="novint_falcon_%k", GROUP="plugdev"
+SUBSYSTEM=="usb", ACTION=="add", ENV{DEVTYPE}=="usb_device", SYSFS{idVendor}=="0403", SYSFS{idProduct}=="cb48", MODE="0664", GROUP="plugdev"


### PR DESCRIPTION
This change to the udev rules allows a non-root user to use the device, as long as they're a member of the "plugdev" group (commonly used by other devices such as digital cameras, at least on Ubuntu).  The old rules set the right permissions on the /dev/novint_falcon_..... symlink but wouldn't change the permissions on the /dev/usb/bus... target of the symlink. I couldn't get the permissions changed, but it would let me change the group, and that appears to be what other software does, so I let it be with that.
