### PR TITLE
Fix for boost thread that requires system since 1.50 or so

### DIFF
--- a/src/util/CMakeLists.txt
+++ b/src/util/CMakeLists.txt
@@ -33,8 +33,13 @@ IF(Boost_THREAD_FOUND)
   SET(CPP_LINK_LIBS 
     ${libnifalcon_LIBRARY}
     ${LIBNIFALCON_REQ_LIBS}
-    ${Boost_THREAD_LIBRARY}
+    ${Boost_THREAD_LIBRARY}	
     )
+
+  # Boost thread requires system since 1.5x
+  IF(Boost_SYSTEM_FOUND)
+    LIST(APPEND CPP_LINK_LIBS "${Boost_SYSTEM_LIBRARY}")
+  ENDIF()
 
   SET(SRCS
 	"FalconDeviceBoostThread.cpp" 


### PR DESCRIPTION
Hi Kyle,

Solved after trying to compile libnifalcon on OSX 10.8.3.

From http://www.boost.org/doc/libs/1_50_0/doc/html/thread/build.html

Boost.Thread uses by default Boost.System to define the exceptions. For backward compatibility and also for compilers that don't work well with Boost.System the user can define BOOST_THREAD_DONT_USE_SYSTEM .
BOOST_THREAD_USES_SYSTEM is defined when Boost.Thread uses Boost.Move.

Best regards,
Christian
